### PR TITLE
改善: フォークからのPRにRuffフォーマット差分をコメントで通知する機能を追加

### DIFF
--- a/.github/workflows/ruff-check.yml
+++ b/.github/workflows/ruff-check.yml
@@ -56,8 +56,11 @@ jobs:
             echo "changed=false" >>"$GITHUB_OUTPUT"
           else
             echo "changed=true" >>"$GITHUB_OUTPUT"
+            # フォーマット変更の差分を保存
+            git diff > /tmp/format_changes.diff
           fi
 
+      # 同一リポジトリからのPRの場合は自動コミット
       - name: Commit formatted code
         if: ${{ github.event_name == 'pull_request' && steps.fmt_changed.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: EndBug/add-and-commit@v9
@@ -65,6 +68,37 @@ jobs:
           message: "style: apply ruff format"
           add: "."
           default_author: github_actions
+          
+      # フォークからのPRの場合はコメントで差分を通知
+      - name: Comment on PR with format changes
+        if: ${{ github.event_name == 'pull_request' && steps.fmt_changed.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const diff = fs.readFileSync('/tmp/format_changes.diff', 'utf8');
+            
+            const body = `## Ruff フォーマット修正が必要です
+            
+            このPRには、Ruffフォーマッターによる修正が必要です。以下の変更を適用してください：
+            
+            \`\`\`diff
+            ${diff}
+            \`\`\`
+            
+            修正方法:
+            1. 上記の変更を手動で適用する
+            2. または \`ruff format .\` を実行して自動修正する
+            
+            変更を適用後、再度プッシュしてください。`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
 
       # ---------- 共通：Lint と型ヒントチェック ----------
       - name: Ruff lint (all rules)

--- a/pr_analysis/json_to_csv.py
+++ b/pr_analysis/json_to_csv.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
-import json
 import csv
+import json
 import sys
-import os
 from pathlib import Path
 
 def convert_json_to_csv(json_file_path, output_csv_path=None):
@@ -27,7 +26,7 @@ def convert_json_to_csv(json_file_path, output_csv_path=None):
     
     try:
         # JSONファイルを読み込む
-        with open(json_file_path, 'r', encoding='utf-8') as f:
+        with open(json_file_path, encoding='utf-8') as f:
             data = json.load(f)
         
         # データが配列であることを確認


### PR DESCRIPTION
# 改善: フォークからのPRにRuffフォーマット差分をコメントで通知する機能を追加

## 問題点

GitHub Actionsの自動フォーマット修正機能が、フォークからのPRに対して機能していませんでした。これは、GitHub Actionsがフォークリポジトリに直接プッシュする権限を持っていないためです。

## 変更内容

フォークからのPRでも自動フォーマットの問題を解決するために、以下の改善を行いました：

1. フォーマット変更の差分を `/tmp/format_changes.diff` に保存するステップを追加
2. フォークからのPRの場合、自動コミットの代わりにPRにコメントを追加して必要なフォーマット変更を通知する機能を追加
3. コメントには、フォーマットの差分と修正方法（手動適用または`ruff format .`コマンドの実行）を明示

## 期待される効果

この変更により、フォークからのPR作成者も自分で必要な修正を行えるようになり、Ruffフォーマットの問題が再発することを防ぎます。

Link to Devin run: https://app.devin.ai/sessions/22e5bd72f4ff48069678837d6d0fabd8
Requested by: NISHIO Hirokazu (nishio.hirokazu@gmail.com)
