### PR TITLE
PR取得とレポート生成の処理を分離

### DIFF
--- a/pr_analysis/pr_analyzer.py
+++ b/pr_analysis/pr_analyzer.py
@@ -85,22 +85,52 @@ def check_rate_limit():
     return remaining, reset_time
 
 
-def get_open_pull_requests(limit=None):
-    """オープン状態のPull Requestを取得する"""
+def get_pull_requests(limit=None, sort_by="updated", direction="desc", last_updated_at=None, state="open"):
+    """Pull Requestを取得する
+    
+    Args:
+        limit: 取得するPRの最大数
+        sort_by: ソート基準 ("created", "updated", "popularity", "long-running")
+        direction: ソート方向 ("asc" or "desc")
+        last_updated_at: 前回実行時の最新更新日時（この日時以降のPRのみ取得）
+        state: PRの状態 ("open", "closed", "all")
+    """
     all_prs = []
     page = 1
     per_page = 100
 
     while True:
         url = f"{API_BASE_URL}/repos/{REPO_OWNER}/{REPO_NAME}/pulls"
-        params = {"state": "open", "per_page": per_page, "page": page}
+        params = {
+            "state": state, 
+            "per_page": per_page, 
+            "page": page,
+            "sort": sort_by,
+            "direction": direction
+        }
 
         try:
             prs = make_github_api_request(url, params=params)
             if not prs:
                 break
 
-            all_prs.extend(prs)
+            if last_updated_at:
+                new_prs = []
+                for pr in prs:
+                    pr_updated_at = datetime.datetime.fromisoformat(pr["updated_at"].replace("Z", "+00:00"))
+                    if pr_updated_at <= last_updated_at:
+                        print(f"前回処理済みのPR #{pr['number']} に到達しました。処理を終了します。")
+                        break
+                    new_prs.append(pr)
+                
+                if len(new_prs) < len(prs):
+                    all_prs.extend(new_prs)
+                    break
+                
+                all_prs.extend(new_prs)
+            else:
+                all_prs.extend(prs)
+            
             page += 1
 
             if limit and len(all_prs) >= limit:
@@ -109,11 +139,22 @@ def get_open_pull_requests(limit=None):
 
             if page > 1:
                 time.sleep(0.5)  # APIレート制限を考慮して少し待機
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 403 and "API rate limit exceeded" in e.response.text:
+                print("GitHubのAPIレート制限に達しました。処理を終了します。")
+                break
+            print(f"PRリスト取得中にエラーが発生しました (ページ {page}): {e}")
+            break
         except Exception as e:
             print(f"PRリスト取得中にエラーが発生しました (ページ {page}): {e}")
             break
 
     return all_prs
+
+
+def get_open_pull_requests(limit=None):
+    """オープン状態のPull Requestを取得する（後方互換性のため）"""
+    return get_pull_requests(limit=limit, state="open")
 
 
 def get_pr_basic_info(pr_number):
@@ -146,17 +187,35 @@ def get_pr_files(pr_number):
     return make_github_api_request(url)
 
 
+def get_pr_labels(pr_number):
+    """PRのラベル情報を取得する"""
+    url = f"{API_BASE_URL}/repos/{REPO_OWNER}/{REPO_NAME}/issues/{pr_number}/labels"
+    return make_github_api_request(url)
+
+
 def get_pr_details(
     pr_number,
     include_comments=True,
     include_review_comments=True,
     include_commits=True,
     include_files=True,
+    include_labels=True,
 ):
     """PRの詳細情報を取得する（オプションで取得する情報を選択可能）"""
     pr_data = get_pr_basic_info(pr_number)
 
-    pr_details = {"basic_info": pr_data}
+    pr_details = {
+        "basic_info": pr_data,
+        "state": pr_data["state"],  # open または closed
+        "updated_at": pr_data["updated_at"]  # 更新日時を保存
+    }
+
+    if include_labels:
+        try:
+            pr_details["labels"] = get_pr_labels(pr_number)
+        except Exception as e:
+            print(f"PR #{pr_number} のラベル取得中にエラーが発生しました: {str(e)[:200]}")
+            pr_details["labels"] = []
 
     if include_comments:
         pr_details["comments"] = get_pr_comments(pr_number)
@@ -179,6 +238,7 @@ def process_pr(
     include_review_comments=True,
     include_commits=True,
     include_files=True,
+    include_labels=True,
 ):
     """1つのPRを処理する（並列処理用）"""
     try:
@@ -190,6 +250,7 @@ def process_pr(
                 include_review_comments=include_review_comments,
                 include_commits=include_commits,
                 include_files=include_files,
+                include_labels=include_labels,
             )
         except Exception as e:
             print(f"PR #{pr_number} の処理中にエラーが発生しました: {str(e)[:200]}")
@@ -204,6 +265,61 @@ def save_to_json(data, filename):
     with open(filename, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
     print(f"JSONデータを {filename} に保存しました")
+
+
+def save_last_run_info(output_dir, last_updated_at):
+    """最後の実行情報を保存する"""
+    last_run_info = {
+        "last_updated_at": last_updated_at.isoformat(),
+        "timestamp": datetime.datetime.now().isoformat()
+    }
+    
+    last_run_file = Path(output_dir) / "last_run_info.json"
+    with open(last_run_file, "w", encoding="utf-8") as f:
+        json.dump(last_run_info, f, ensure_ascii=False, indent=2)
+    print(f"最後の実行情報を {last_run_file} に保存しました")
+
+
+def load_last_run_info(base_output_dir):
+    """最後の実行情報を読み込む"""
+    last_run_file = Path(base_output_dir) / "last_run_info.json"
+    
+    if last_run_file.exists():
+        try:
+            with open(last_run_file, "r", encoding="utf-8") as f:
+                last_run_info = json.load(f)
+            
+            last_updated_at = datetime.datetime.fromisoformat(last_run_info["last_updated_at"])
+            print(f"前回の実行情報を読み込みました: 最終更新日時 = {last_updated_at}")
+            return last_updated_at
+        except Exception as e:
+            print(f"前回の実行情報の読み込み中にエラーが発生しました: {e}")
+    
+    print("前回の実行情報が見つかりませんでした")
+    return None
+
+
+def load_previous_prs_data(base_output_dir):
+    """前回のPRデータを読み込む"""
+    dirs = [d for d in Path(base_output_dir).glob("*") if d.is_dir() and d.name[0].isdigit()]
+    if not dirs:
+        print("前回のPRデータが見つかりませんでした")
+        return []
+    
+    latest_dir = max(dirs, key=lambda d: d.stat().st_mtime)
+    json_file = latest_dir / "prs_data.json"
+    
+    if json_file.exists():
+        try:
+            with open(json_file, "r", encoding="utf-8") as f:
+                prs_data = json.load(f)
+            print(f"前回のPRデータを読み込みました: {len(prs_data)}件 ({json_file})")
+            return prs_data
+        except Exception as e:
+            print(f"前回のPRデータの読み込み中にエラーが発生しました: {e}")
+    
+    print("前回のPRデータが見つかりませんでした")
+    return []
 
 
 def generate_markdown(prs_data, filename):
@@ -386,6 +502,28 @@ def parse_arguments():
         default="",
         help="出力ディレクトリ (デフォルト: timestamp)",
     )
+    parser.add_argument(
+        "--ignore-last-run",
+        action="store_true",
+        help="前回の実行情報を無視して全PRを取得する",
+    )
+    parser.add_argument(
+        "--open-only",
+        action="store_true",
+        help="オープン状態のPRのみを取得する",
+    )
+    parser.add_argument(
+        "--filter-state",
+        type=str,
+        choices=["open", "closed"],
+        help="指定した状態のPRのみをレポートに含める",
+    )
+    parser.add_argument(
+        "--base-output-dir",
+        type=str,
+        default="pr_analysis_results",
+        help="基本出力ディレクトリ (デフォルト: pr_analysis_results)",
+    )
 
     return parser.parse_args()
 
@@ -543,11 +681,14 @@ def generate_file_based_markdown(prs_data, output_dir):
 def main():
     args = parse_arguments()
 
-    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_dir = Path(args.output_dir or timestamp)
-    output_dir.mkdir(exist_ok=True)
+    base_output_dir = Path(args.base_output_dir)
+    base_output_dir.mkdir(exist_ok=True)
 
-    print("team-mirai/policy リポジトリのオープンPRを収集しています...")
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_dir or f"{base_output_dir}/{timestamp}")
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    print(f"team-mirai/{REPO_NAME} リポジトリのPRを収集しています...")
 
     remaining, reset_time = check_rate_limit()
     if remaining < 100:
@@ -558,13 +699,30 @@ def main():
             print("処理を中止します。")
             return
 
-    limit = args.limit if args.limit > 0 else None
-    open_prs = get_open_pull_requests(limit)
-    print(f"{len(open_prs)}件のオープンPRを見つけました")
+    last_updated_at = None
+    if not args.ignore_last_run:
+        last_updated_at = load_last_run_info(base_output_dir)
 
-    if not open_prs:
-        print("オープンなPRがありません。処理を終了します。")
+    limit = args.limit if args.limit > 0 else None
+    pr_state = "open" if args.open_only else "all"
+    
+    prs = get_pull_requests(
+        limit=limit, 
+        sort_by="updated", 
+        direction="desc", 
+        last_updated_at=last_updated_at,
+        state=pr_state
+    )
+    
+    print(f"{len(prs)}件のPRを見つけました")
+
+    if not prs:
+        print("処理対象のPRがありません。処理を終了します。")
         return
+
+    previous_prs_data = []
+    if not args.ignore_last_run and last_updated_at:
+        previous_prs_data = load_previous_prs_data(base_output_dir)
 
     print(f"{args.workers}個のワーカーで並列処理を開始します...")
 
@@ -580,8 +738,9 @@ def main():
                 include_review_comments=not args.no_review_comments,
                 include_commits=not args.no_commits,
                 include_files=not args.no_files,
+                include_labels=True,  # ラベル情報は常に取得
             )
-            for pr in open_prs
+            for pr in prs
         ]
 
         for future in tqdm(
@@ -595,6 +754,20 @@ def main():
             else:
                 error_prs.append("不明なPR")  # PR番号が取得できない場合
 
+    if previous_prs_data:
+        current_pr_ids = {pr["basic_info"]["number"] for pr in valid_prs_data}
+        
+        for pr in previous_prs_data:
+            if pr["basic_info"]["number"] not in current_pr_ids:
+                valid_prs_data.append(pr)
+        
+        print(f"前回のデータと統合: 合計{len(valid_prs_data)}件のPR")
+
+    filtered_prs_data = valid_prs_data
+    if args.filter_state:
+        filtered_prs_data = [pr for pr in valid_prs_data if pr["state"] == args.filter_state]
+        print(f"状態 '{args.filter_state}' でフィルタリング: {len(filtered_prs_data)}/{len(valid_prs_data)}件")
+
     print(f"処理結果: 成功={len(valid_prs_data)}件, エラー={len(error_prs)}件")
 
     if error_prs:
@@ -605,19 +778,27 @@ def main():
                 f.write(f"{pr_info}\n")
         print(f"エラーが発生したPRの情報を {error_log_path} に保存しました")
 
+    if valid_prs_data:
+        latest_updated_at = max(
+            datetime.datetime.fromisoformat(pr["updated_at"].replace("Z", "+00:00"))
+            for pr in valid_prs_data
+            if "updated_at" in pr
+        )
+        save_last_run_info(base_output_dir, latest_updated_at)
+
     json_filename = output_dir / "prs_data.json"
     save_to_json(valid_prs_data, json_filename)
 
     md_filename = output_dir / "prs_report.md"
-    generate_markdown(valid_prs_data, md_filename)
+    generate_markdown(filtered_prs_data, md_filename)
 
     summary_md_filename = output_dir / "prs_summary.md"
-    generate_summary_markdown(valid_prs_data, summary_md_filename)
+    generate_summary_markdown(filtered_prs_data, summary_md_filename)
 
     issues_diffs_md_filename = output_dir / "prs_issues_diffs.md"
-    generate_issues_and_diffs_markdown(valid_prs_data, issues_diffs_md_filename)
+    generate_issues_and_diffs_markdown(filtered_prs_data, issues_diffs_md_filename)
 
-    generate_file_based_markdown(valid_prs_data, output_dir)
+    generate_file_based_markdown(filtered_prs_data, output_dir)
 
     print("処理が完了しました。")
     print(f"JSON出力: {json_filename}")


### PR DESCRIPTION
# PR取得とレポート生成の処理分離

## 実装内容

1. **処理モードの追加**
   - `--mode` パラメータを追加し、以下の3つのモードを選択可能に:
     - `fetch`: PRデータのみ取得してJSONに保存（API消費）
     - `report`: 既存JSONからレポートのみ生成（API消費なし）
     - `both`: 両方実行（デフォルト）

2. **処理の分離**
   - `fetch_pr_data()`: GitHub APIを使用してPRデータを取得・保存する関数
   - `generate_reports()`: JSONデータからレポートを生成する関数
   - `main()`: モードに応じて上記関数を呼び出す

3. **JSONファイル指定オプション**
   - `--input-json`: レポートモード時に使用するJSONファイルを指定

4. **差分収集の最適化**
   - 更新順にPRを取得し、既に取得済みのPRと同じ時刻のものが来たらbreakする
   - Rate Limitに達した場合は処理を終了する（次回実行時に続きから取得可能）
   - PR状態（open/closed）とラベル情報を保存し、JSONからの分析時にフィルタリング可能

## メリット

1. **API制限の効率的な利用**
   - レポート生成のみの場合はAPIを消費しない
   - 同じJSONから異なるフィルタ条件で複数のレポートを生成可能
   - 差分収集により必要最小限のAPI呼び出しで最新データを維持

2. **柔軟な運用**
   - PR取得とレポート生成を別々のタイミングで実行可能
   - 複数の異なる出力形式やフィルタ条件でのレポート生成が容易
   - Rate Limitに達した場合でも次回実行時に続きから取得可能
