### PR TITLE
PR分析: READMEを対象とするPRの分類機能を追加

### DIFF
--- a/.github/workflows/pr_analyzer.yml
+++ b/.github/workflows/pr_analyzer.yml
@@ -1,0 +1,37 @@
+name: PR分析とREADME対象PR分類
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # 毎週日曜日の午前0時に実行
+  workflow_dispatch:  # 手動実行も可能にする
+
+jobs:
+  analyze_prs:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: リポジトリのチェックアウト
+        uses: actions/checkout@v3
+        
+      - name: Pythonのセットアップ
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          
+      - name: 依存パッケージのインストール
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests backoff tqdm
+          
+      - name: PR分析の実行
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          python pr_analysis/pr_analyzer.py --mode both --classify-readme --fetch-mode priority
+          
+      - name: 分析結果のアップロード
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr-analysis-results
+          path: pr_analysis/*_report/

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ python pr_analysis/pr_analyzer.py --mode fetch --fetch-mode priority
 ```
 
 これにより、まだ取得できていないPRを優先的に取得し、残りの制限数で更新されたPRを取得します。
+
+### 新機能: README対象PRの分類
+
+READMEを対象とするPRを内容に基づいて分類することができます：
+
+```
+python pr_analysis/pr_analyzer.py --mode report --classify-readme --input-json pr_analysis/[timestamp]/prs_data.json
+```
+
+このコマンドを実行すると、READMEを対象とするPRが内容に基づいて既存のマークダウンファイルに分類され、結果が`classified`ディレクトリに保存されます。
+
+> **注**: この機能を使用するには、環境変数`OPENROUTER_API_KEY`にOpenRouter APIキーを設定する必要があります。

--- a/pr_analysis/content_classifier.py
+++ b/pr_analysis/content_classifier.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import os
+import requests
+import json
+from pathlib import Path
+import backoff
+
+class ContentClassifier:
+    """PRの内容を分析し、適切なカテゴリに分類するクラス"""
+    
+    def __init__(self, api_key=None, repo_root=None):
+        """初期化
+        
+        Args:
+            api_key: OpenRouter APIキー（Noneの場合は環境変数から取得）
+            repo_root: リポジトリのルートディレクトリ（Noneの場合はカレントディレクトリの親）
+        """
+        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError("OpenRouter APIキーが設定されていません。環境変数OPENROUTER_API_KEYを設定してください。")
+        
+        self.repo_root = Path(repo_root) if repo_root else Path(__file__).parent.parent
+        self.existing_files = self._get_existing_files()
+        
+    def _get_existing_files(self):
+        """リポジトリ内の既存のマークダウンファイルを取得する"""
+        existing_files = []
+        for path in self.repo_root.glob("**/*.md"):
+            if "pr_analysis" not in str(path.relative_to(self.repo_root)):
+                existing_files.append(path)
+        return existing_files
+    
+    @backoff.on_exception(
+        backoff.expo,
+        requests.exceptions.RequestException,
+        max_tries=3,
+    )
+    def classify_content(self, pr_data):
+        """PRの内容を分析して分類する
+        
+        Args:
+            pr_data: PR情報を含む辞書
+        
+        Returns:
+            dict: 分類結果（カテゴリ名、信頼度、説明を含む）
+        """
+        content = self._extract_pr_content(pr_data)
+        
+        result = self._analyze_with_openrouter(content)
+        
+        return result
+    
+    def _extract_pr_content(self, pr_data):
+        """PRから分析に必要なテキストを抽出する"""
+        texts = []
+        
+        basic = pr_data.get("basic_info", {})
+        if basic.get("title"):
+            texts.append(f"タイトル: {basic['title']}")
+        if basic.get("body"):
+            texts.append(f"説明: {basic['body']}")
+        
+        commits = pr_data.get("commits", [])
+        commit_msgs = []
+        for commit in commits:
+            if commit.get("commit", {}).get("message"):
+                commit_msgs.append(commit["commit"]["message"])
+        if commit_msgs:
+            texts.append("コミットメッセージ:\n" + "\n".join(commit_msgs))
+        
+        comments = pr_data.get("comments", [])
+        comment_texts = []
+        for comment in comments:
+            if comment.get("body"):
+                comment_texts.append(comment["body"])
+        if comment_texts:
+            texts.append("コメント:\n" + "\n".join(comment_texts))
+        
+        return "\n\n".join(texts)
+    
+    def _analyze_with_openrouter(self, content):
+        """OpenRouter APIを使用してコンテンツを分析する"""
+        url = "https://openrouter.ai/api/v1/chat/completions"
+        
+        file_names = [str(f.relative_to(self.repo_root)) for f in self.existing_files]
+        
+        prompt = f"""
+        あなたはPull Requestの内容を分析し、最も関連性の高いファイルに分類するアシスタントです。
+        以下のPRの内容を分析して、最も関連性の高いマークダウンファイルを選択してください。
+        どのファイルにも関連性がない場合は「分類不能」と判断してください。
+        
+        {content}
+        
+        {', '.join(file_names)}
+        
+        JSONフォーマットで以下の内容を返してください:
+        {{
+          "category": "ファイル名または「分類不能」",
+          "confidence": 0～1の数値（信頼度）,
+          "explanation": "分類理由の簡潔な説明"
+        }}
+        """
+        
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+        
+        data = {
+            "model": "openai/gpt-4o",  # 高性能モデルを使用
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ],
+            "response_format": {"type": "json_object"}
+        }
+        
+        response = requests.post(url, headers=headers, json=data)
+        response.raise_for_status()
+        
+        result = response.json()
+        try:
+            content = result["choices"][0]["message"]["content"]
+            classification = json.loads(content)
+            return classification
+        except (KeyError, json.JSONDecodeError) as e:
+            print(f"APIレスポンスの解析に失敗しました: {e}")
+            return {
+                "category": "分類不能",
+                "confidence": 0.0,
+                "explanation": "APIレスポンスの解析に失敗しました"
+            }
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="PRの内容を分類するツール")
+    parser.add_argument("--input", required=True, help="PRデータを含むJSONファイル")
+    args = parser.parse_args()
+    
+    with open(args.input, "r", encoding="utf-8") as f:
+        pr_data = json.load(f)
+    
+    classifier = ContentClassifier()
+    result = classifier.classify_content(pr_data)
+    print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/pr_analysis/pr_analyzer.py
+++ b/pr_analysis/pr_analyzer.py
@@ -676,6 +676,11 @@ def parse_arguments():
         type=str,
         help="レポート生成に使用するJSONファイルのパス (--mode report の場合に必須)",
     )
+    report_group.add_argument(
+        "--classify-readme",
+        action="store_true",
+        help="README対象のPRを分類する"
+    )
     
     parser.add_argument(
         "--output-dir",
@@ -1015,6 +1020,80 @@ def generate_reports(args, json_path=None, output_dir=None, prs_data=None):
         filtered_prs_data = [pr for pr in prs_data if pr["state"] == args.filter_state]
         print(f"状態 '{args.filter_state}' でフィルタリング: {len(filtered_prs_data)}/{len(prs_data)}件")
     
+    if args.classify_readme:
+        from content_classifier import ContentClassifier
+        classifier = ContentClassifier()
+        
+        readme_prs = []
+        for pr in filtered_prs_data:
+            is_readme_pr = False
+            if "files" in pr and pr["files"]:
+                for file in pr["files"]:
+                    if file["filename"].lower() == "readme.md":
+                        is_readme_pr = True
+                        break
+            
+            if is_readme_pr:
+                readme_prs.append(pr)
+        
+        print(f"README対象PRを検出: {len(readme_prs)}件")
+        
+        if readme_prs:
+            classified_dir = output_dir / "classified"
+            classified_dir.mkdir(exist_ok=True)
+            
+            with open(classified_dir / "classification_summary.md", "w", encoding="utf-8") as summary_f:
+                summary_f.write("# README対象PRの分類結果\n\n")
+                summary_f.write("| PR番号 | タイトル | 分類カテゴリ | 信頼度 | 説明 |\n")
+                summary_f.write("|--------|----------|--------------|--------|------|\n")
+                
+                categories = {}
+                
+                for pr in tqdm(readme_prs, desc="README対象PRの分類"):
+                    classification = classifier.classify_content(pr)
+                    category = classification.get("category", "分類不能")
+                    confidence = classification.get("confidence", 0.0)
+                    explanation = classification.get("explanation", "")
+                    
+                    basic = pr["basic_info"]
+                    pr_number = basic["number"]
+                    title = basic["title"]
+                    
+                    summary_f.write(f"| #{pr_number} | {title} | {category} | {confidence:.2f} | {explanation} |\n")
+                    
+                    if category not in categories:
+                        categories[category] = []
+                    categories[category].append((pr, classification))
+                
+                summary_f.write(f"\n## 分類統計\n\n")
+                for category, prs in sorted(categories.items()):
+                    summary_f.write(f"- {category}: {len(prs)}件\n")
+            
+            for category, prs in categories.items():
+                safe_category = category.replace("/", "_").replace("\\", "_")
+                category_file = classified_dir / f"{safe_category}.md"
+                
+                with open(category_file, "w", encoding="utf-8") as f:
+                    f.write(f"# カテゴリ: {category} の Pull Requests\n\n")
+                    
+                    for pr, classification in prs:
+                        basic = pr["basic_info"]
+                        pr_number = basic["number"]
+                        title = basic["title"]
+                        confidence = classification.get("confidence", 0.0)
+                        explanation = classification.get("explanation", "")
+                        
+                        f.write(f"## #{pr_number}: {title}\n\n")
+                        f.write(f"- 信頼度: {confidence:.2f}\n")
+                        f.write(f"- 分類理由: {explanation}\n\n")
+                        
+                        if basic["body"]:
+                            f.write(f"### PR内容\n\n{basic['body']}\n\n")
+                        
+                        f.write("---\n\n")
+            
+            print(f"README対象PRの分類結果を {classified_dir} に保存しました")
+    
     md_filename = output_dir / "prs_report.md"
     generate_markdown(filtered_prs_data, md_filename)
 
@@ -1031,6 +1110,16 @@ def generate_reports(args, json_path=None, output_dir=None, prs_data=None):
     print(f"サマリーMarkdown出力: {summary_md_filename}")
     print(f"Issues内容と変更差分出力: {issues_diffs_md_filename}")
     print(f"ファイルごとのMarkdown出力: {output_dir / 'files'} (インデックス: {output_dir / 'files_index.md'})")
+    
+    if args.classify_readme:
+        # readme_prsとclassified_dirが定義されている場合のみ出力
+        classification_summary_path = None
+        if 'readme_prs' in locals() and readme_prs:
+            if 'classified_dir' in locals():
+                classification_summary_path = classified_dir / 'classification_summary.md'
+        
+        if classification_summary_path:
+            print(f"README対象PR分類結果: {classification_summary_path}")
 
 
 def main():


### PR DESCRIPTION
# PR分析: READMEを対象とするPRの分類機能を追加

## 概要
このPRでは、READMEを対象とするPRを内容に基づいて分類する機能を追加しました。現在、READMEを対象とするPRが280件以上あり、これらをより詳細な内容に基づいて他のファイルやカテゴリに分配し直す必要があります。

## 変更内容
1. **新規モジュール `content_classifier.py` の作成**
   - OpenRouter APIを使用してPR内容を分析・分類する機能を実装
   - 既存のマークダウンファイルまたは「分類不能」カテゴリに分類

2. **`pr_analyzer.py` の拡張**
   - `--classify-readme` オプションを追加
   - README対象PRの分類機能を実装
   - 分類結果を `classified` ディレクトリに保存

3. **GitHub Actionsワークフローの追加**
   - 毎週日曜日に自動実行するワークフローを設定
   - PR分析と分類を自動化

4. **READMEの更新**
   - 新機能の使用方法を追加
   - 必要な環境変数の説明を追加

## 使用方法
```
python pr_analysis/pr_analyzer.py --mode report --classify-readme --input-json pr_analysis/[timestamp]/prs_data.json
```

## 注意事項
- この機能を使用するには、環境変数 `OPENROUTER_API_KEY` にOpenRouter APIキーを設定する必要があります
- 将来的には「未整理」ラベルのPRも同様に分類できるように拡張予定

## テスト
- 少数のPRサンプルで分類機能をテスト済み
- 分類精度は実際のデータで継続的に評価・改善予定

Link to Devin run: https://app.devin.ai/sessions/6a676390420940b7b40e087f5dbb882d
Requested by: NISHIO Hirokazu (nishio.hirokazu@gmail.com)
