### PR TITLE
Fix sequential fetch issue

### DIFF
--- a/pr_analysis/pr_analyzer.py
+++ b/pr_analysis/pr_analyzer.py
@@ -169,6 +169,8 @@ def get_pull_requests_sequential(start_id=1, max_id=None, limit=None):
                 count += 1
             else:
                 print(f"PR #{current_id} は存在しないためスキップします")
+                print(f"PR #{current_id} が存在しないため、これ以上のPRは存在しないと判断して処理を終了します。")
+                break
             
             current_id += 1
             


### PR DESCRIPTION
# PR: Fix sequential fetch issue

## 概要
シーケンシャルフェッチモードで存在しないPR IDに遭遇した場合、処理を中断するように修正しました。

## 変更内容
- `get_pull_requests_sequential`関数を修正し、存在しないPR IDに1回遭遇した時点で処理を中断するようにしました
- PR IDは連番であるため、存在しないIDに遭遇した場合はそれ以降のIDにも有効なPRが存在しない可能性が高いという前提に基づいています

## テスト方法
以下のコマンドで動作確認できます：
```
python pr_analysis/pr_analyzer.py --mode fetch --fetch-mode sequential --ignore-last-run
```

## 要求者
NISHIO Hirokazu (nishio.hirokazu@gmail.com)

## Devinセッションリンク
https://app.devin.ai/sessions/be97f3bb5bc24d768d4bf386611c2f6a
