### PR TITLE
PRデータ統合スクリプトの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ python pr_analysis/pr_analyzer.py --mode fetch --fetch-mode priority
 python pr_analysis/merge_pr_data.py
 ```
 
-このコマンドは、すべての`pr_analysis_results`ディレクトリから`prs_data.json`ファイルを読み込み、
-重複を除去して一つの統合ファイル（`pr_analysis_results/merged/merged_prs_data.json`）に保存します。
+このコマンドは、デフォルトで4つのディレクトリ（20250521_021502、20250521_034352、20250521_034935、20250521_094649）から
+`prs_data.json`ファイルを読み込み、重複を除去して一つの統合ファイル（`pr_analysis_results/merged/merged_prs_data.json`）に保存します。
+現在の統合ファイルには、PR番号1～1368の範囲から1361個のPRが含まれています（7つのPRは元のデータに含まれていません）。
 
 特定のディレクトリのみを統合する場合：
 
@@ -66,6 +67,12 @@ python pr_analysis/merge_pr_data.py --specific-dirs 20250521_034352 20250521_034
 
 ```
 python pr_analysis/merge_pr_data.py --no-update --output-file path/to/output.json
+```
+
+統合されたPRデータを検証するには、以下のコマンドを使用します：
+
+```
+python pr_analysis/verify_pr_data.py
 ```
 
 ### 新機能: README対象PRの分類

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - `.github/`: GitHubの設定ファイル（Issue・PRテンプレート、ワークフロー）
 - 各種構成ファイル: Biome, VSCode設定など
 - `pr_analysis/`: PR分析ツール（詳細は[pr_analysis/README.md](pr_analysis/README.md)を参照）
+  - `pr_analysis/merge_pr_data.py`: 複数のPRデータファイルを統合するスクリプト
 
 ## PR分析ツールの使用方法
 
@@ -43,6 +44,29 @@ python pr_analysis/pr_analyzer.py --mode fetch --fetch-mode priority
 ```
 
 これにより、まだ取得できていないPRを優先的に取得し、残りの制限数で更新されたPRを取得します。
+
+### PRデータの統合
+
+複数のディレクトリに分散したPRデータを統合するには、以下のコマンドを使用します：
+
+```
+python pr_analysis/merge_pr_data.py
+```
+
+このコマンドは、すべての`pr_analysis_results`ディレクトリから`prs_data.json`ファイルを読み込み、
+重複を除去して一つの統合ファイル（`pr_analysis_results/merged/merged_prs_data.json`）に保存します。
+
+特定のディレクトリのみを統合する場合：
+
+```
+python pr_analysis/merge_pr_data.py --specific-dirs 20250521_034352 20250521_034935 20250521_094649
+```
+
+既存の統合ファイルを更新せず、新しいファイルを作成する場合：
+
+```
+python pr_analysis/merge_pr_data.py --no-update --output-file path/to/output.json
+```
 
 ### 新機能: README対象PRの分類
 

--- a/pr_analysis/check_pr_counts.py
+++ b/pr_analysis/check_pr_counts.py
@@ -8,6 +8,7 @@ import os
 import glob
 from pathlib import Path
 
+
 def count_prs_in_file(file_path):
     """ファイル内のPR数を数える"""
     try:
@@ -18,24 +19,25 @@ def count_prs_in_file(file_path):
         print(f"Error loading {file_path}: {e}")
         return 0
 
+
 def main():
     repo_root = Path(__file__).parent.parent.absolute()
-    
+
     dirs_to_check = ["20250521_021502", "20250521_034352", "20250521_034935", "20250521_094649"]
     total_count = 0
-    
+
     for dir_name in dirs_to_check:
         file_path = os.path.join(repo_root, "pr_analysis_results", dir_name, "prs_data.json")
         count = count_prs_in_file(file_path)
         print(f"{dir_name}: {count} PRs")
         total_count += count
-    
+
     print(f"合計: {total_count} PRs")
-    
+
     merged_file = os.path.join(repo_root, "pr_analysis_results", "merged", "merged_prs_data.json")
     merged_count = count_prs_in_file(merged_file)
     print(f"統合ファイル: {merged_count} PRs")
-    
+
     if merged_count > 0:
         with open(merged_file, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -43,7 +45,7 @@ def main():
             if pr_numbers:
                 print(f"PR番号の範囲: {min(pr_numbers)} ~ {max(pr_numbers)}")
                 print(f"ユニークなPR番号の数: {len(set(pr_numbers))}")
-                
+
                 missing_prs = []
                 for i in range(1, max(pr_numbers) + 1):
                     if i not in pr_numbers:
@@ -54,6 +56,7 @@ def main():
                         print(f"欠落しているPR番号: {missing_prs}")
                     else:
                         print(f"欠落しているPR番号の一部: {missing_prs[:20]}...")
+
 
 if __name__ == "__main__":
     main()

--- a/pr_analysis/check_pr_counts.py
+++ b/pr_analysis/check_pr_counts.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+PRデータファイルの数を確認するスクリプト
+"""
+
+import json
+import os
+import glob
+from pathlib import Path
+
+def count_prs_in_file(file_path):
+    """ファイル内のPR数を数える"""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return len(data)
+    except Exception as e:
+        print(f"Error loading {file_path}: {e}")
+        return 0
+
+def main():
+    repo_root = Path(__file__).parent.parent.absolute()
+    
+    dirs_to_check = ["20250521_021502", "20250521_034352", "20250521_034935", "20250521_094649"]
+    total_count = 0
+    
+    for dir_name in dirs_to_check:
+        file_path = os.path.join(repo_root, "pr_analysis_results", dir_name, "prs_data.json")
+        count = count_prs_in_file(file_path)
+        print(f"{dir_name}: {count} PRs")
+        total_count += count
+    
+    print(f"合計: {total_count} PRs")
+    
+    merged_file = os.path.join(repo_root, "pr_analysis_results", "merged", "merged_prs_data.json")
+    merged_count = count_prs_in_file(merged_file)
+    print(f"統合ファイル: {merged_count} PRs")
+    
+    if merged_count > 0:
+        with open(merged_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            pr_numbers = [pr.get("basic_info", {}).get("number", 0) for pr in data if "basic_info" in pr]
+            if pr_numbers:
+                print(f"PR番号の範囲: {min(pr_numbers)} ~ {max(pr_numbers)}")
+                print(f"ユニークなPR番号の数: {len(set(pr_numbers))}")
+                
+                missing_prs = []
+                for i in range(1, max(pr_numbers) + 1):
+                    if i not in pr_numbers:
+                        missing_prs.append(i)
+                if missing_prs:
+                    print(f"欠落しているPR番号の数: {len(missing_prs)}")
+                    if len(missing_prs) < 20:
+                        print(f"欠落しているPR番号: {missing_prs}")
+                    else:
+                        print(f"欠落しているPR番号の一部: {missing_prs[:20]}...")
+
+if __name__ == "__main__":
+    main()

--- a/pr_analysis/merge_pr_data.py
+++ b/pr_analysis/merge_pr_data.py
@@ -111,6 +111,7 @@ def main():
     parser.add_argument(
         "--specific-dirs", 
         nargs="+", 
+        default=["20250521_021502", "20250521_034352", "20250521_034935", "20250521_094649"],
         help="Specific directory names to process (e.g. 20250521_034352)"
     )
     

--- a/pr_analysis/merge_pr_data.py
+++ b/pr_analysis/merge_pr_data.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+PR分析データ統合スクリプト
+
+複数のpr_analysis_resultsディレクトリにあるprs_data.jsonファイルを統合し、
+一つの統合されたJSONファイルを作成します。また、今後の更新時には既存の統合ファイルを
+更新することができます。
+"""
+
+import argparse
+import json
+import os
+import glob
+from datetime import datetime
+import logging
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+def load_json_file(file_path):
+    """JSONファイルを読み込む"""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"Error loading {file_path}: {e}")
+        return []
+
+def save_json_file(data, file_path):
+    """JSONファイルを保存する"""
+    try:
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        logger.info(f"Saved merged data to {file_path}")
+        return True
+    except Exception as e:
+        logger.error(f"Error saving to {file_path}: {e}")
+        return False
+
+def merge_pr_data(input_dirs=None, output_file=None, update_existing=True):
+    """
+    複数のディレクトリからPRデータを統合する
+    
+    Args:
+        input_dirs: 入力ディレクトリのリスト（指定がない場合は全てのpr_analysis_resultsディレクトリを使用）
+        output_file: 出力ファイルパス
+        update_existing: 既存の統合ファイルを更新するかどうか
+    
+    Returns:
+        統合されたデータの数
+    """
+    if output_file is None:
+        output_file = os.path.join("pr_analysis_results", "merged", "merged_prs_data.json")
+    
+    existing_data = []
+    existing_pr_ids = set()
+    if update_existing and os.path.exists(output_file):
+        existing_data = load_json_file(output_file)
+        existing_pr_ids = {pr.get("basic_info", {}).get("id") for pr in existing_data if "basic_info" in pr}
+        logger.info(f"Loaded {len(existing_data)} existing PRs from {output_file}")
+    
+    if input_dirs is None:
+        base_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pr_analysis_results")
+        input_dirs = [d for d in glob.glob(os.path.join(base_dir, "*")) if os.path.isdir(d)]
+    
+    all_prs = []
+    for input_dir in input_dirs:
+        data_file = os.path.join(input_dir, "prs_data.json")
+        if os.path.exists(data_file):
+            prs_data = load_json_file(data_file)
+            logger.info(f"Loaded {len(prs_data)} PRs from {data_file}")
+            all_prs.extend(prs_data)
+    
+    merged_data = existing_data.copy() if update_existing else []
+    new_count = 0
+    
+    for pr in all_prs:
+        pr_id = pr.get("basic_info", {}).get("id")
+        if pr_id and pr_id not in existing_pr_ids:
+            merged_data.append(pr)
+            existing_pr_ids.add(pr_id)
+            new_count += 1
+    
+    if save_json_file(merged_data, output_file):
+        logger.info(f"Merged data saved successfully. Added {new_count} new PRs, total: {len(merged_data)}")
+    
+    return len(merged_data)
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge PR data from multiple directories")
+    parser.add_argument(
+        "--input-dirs", 
+        nargs="+", 
+        help="Input directories containing prs_data.json files (default: all pr_analysis_results directories)"
+    )
+    parser.add_argument(
+        "--output-file", 
+        default=os.path.join("pr_analysis_results", "merged", "merged_prs_data.json"),
+        help="Output file path for merged data"
+    )
+    parser.add_argument(
+        "--no-update", 
+        action="store_true",
+        help="Don't update existing merged file, create a new one instead"
+    )
+    parser.add_argument(
+        "--specific-dirs", 
+        nargs="+", 
+        help="Specific directory names to process (e.g. 20250521_034352)"
+    )
+    
+    args = parser.parse_args()
+    
+    if args.specific_dirs:
+        base_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pr_analysis_results")
+        input_dirs = [os.path.join(base_dir, d) for d in args.specific_dirs]
+        logger.info(f"Processing specific directories: {args.specific_dirs}")
+    else:
+        input_dirs = args.input_dirs
+    
+    total_prs = merge_pr_data(
+        input_dirs=input_dirs,
+        output_file=args.output_file,
+        update_existing=not args.no_update
+    )
+    
+    logger.info(f"Completed merging PR data. Total PRs in merged file: {total_prs}")
+
+if __name__ == "__main__":
+    main()

--- a/pr_analysis/merge_pr_data.py
+++ b/pr_analysis/merge_pr_data.py
@@ -21,6 +21,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
 def load_json_file(file_path):
     """JSONファイルを読み込む"""
     try:
@@ -29,6 +30,7 @@ def load_json_file(file_path):
     except Exception as e:
         logger.error(f"Error loading {file_path}: {e}")
         return []
+
 
 def save_json_file(data, file_path):
     """JSONファイルを保存する"""
@@ -42,32 +44,33 @@ def save_json_file(data, file_path):
         logger.error(f"Error saving to {file_path}: {e}")
         return False
 
+
 def merge_pr_data(input_dirs=None, output_file=None, update_existing=True):
     """
     複数のディレクトリからPRデータを統合する
-    
+
     Args:
         input_dirs: 入力ディレクトリのリスト（指定がない場合は全てのpr_analysis_resultsディレクトリを使用）
         output_file: 出力ファイルパス
         update_existing: 既存の統合ファイルを更新するかどうか
-    
+
     Returns:
         統合されたデータの数
     """
     if output_file is None:
         output_file = os.path.join("pr_analysis_results", "merged", "merged_prs_data.json")
-    
+
     existing_data = []
     existing_pr_ids = set()
     if update_existing and os.path.exists(output_file):
         existing_data = load_json_file(output_file)
         existing_pr_ids = {pr.get("basic_info", {}).get("id") for pr in existing_data if "basic_info" in pr}
         logger.info(f"Loaded {len(existing_data)} existing PRs from {output_file}")
-    
+
     if input_dirs is None:
         base_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pr_analysis_results")
         input_dirs = [d for d in glob.glob(os.path.join(base_dir, "*")) if os.path.isdir(d)]
-    
+
     all_prs = []
     for input_dir in input_dirs:
         data_file = os.path.join(input_dir, "prs_data.json")
@@ -75,62 +78,58 @@ def merge_pr_data(input_dirs=None, output_file=None, update_existing=True):
             prs_data = load_json_file(data_file)
             logger.info(f"Loaded {len(prs_data)} PRs from {data_file}")
             all_prs.extend(prs_data)
-    
+
     merged_data = existing_data.copy() if update_existing else []
     new_count = 0
-    
+
     for pr in all_prs:
         pr_id = pr.get("basic_info", {}).get("id")
         if pr_id and pr_id not in existing_pr_ids:
             merged_data.append(pr)
             existing_pr_ids.add(pr_id)
             new_count += 1
-    
+
     if save_json_file(merged_data, output_file):
         logger.info(f"Merged data saved successfully. Added {new_count} new PRs, total: {len(merged_data)}")
-    
+
     return len(merged_data)
+
 
 def main():
     parser = argparse.ArgumentParser(description="Merge PR data from multiple directories")
     parser.add_argument(
-        "--input-dirs", 
-        nargs="+", 
-        help="Input directories containing prs_data.json files (default: all pr_analysis_results directories)"
+        "--input-dirs",
+        nargs="+",
+        help="Input directories containing prs_data.json files (default: all pr_analysis_results directories)",
     )
     parser.add_argument(
-        "--output-file", 
+        "--output-file",
         default=os.path.join("pr_analysis_results", "merged", "merged_prs_data.json"),
-        help="Output file path for merged data"
+        help="Output file path for merged data",
     )
     parser.add_argument(
-        "--no-update", 
-        action="store_true",
-        help="Don't update existing merged file, create a new one instead"
+        "--no-update", action="store_true", help="Don't update existing merged file, create a new one instead"
     )
     parser.add_argument(
-        "--specific-dirs", 
-        nargs="+", 
+        "--specific-dirs",
+        nargs="+",
         default=["20250521_021502", "20250521_034352", "20250521_034935", "20250521_094649"],
-        help="Specific directory names to process (e.g. 20250521_034352)"
+        help="Specific directory names to process (e.g. 20250521_034352)",
     )
-    
+
     args = parser.parse_args()
-    
+
     if args.specific_dirs:
         base_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pr_analysis_results")
         input_dirs = [os.path.join(base_dir, d) for d in args.specific_dirs]
         logger.info(f"Processing specific directories: {args.specific_dirs}")
     else:
         input_dirs = args.input_dirs
-    
-    total_prs = merge_pr_data(
-        input_dirs=input_dirs,
-        output_file=args.output_file,
-        update_existing=not args.no_update
-    )
-    
+
+    total_prs = merge_pr_data(input_dirs=input_dirs, output_file=args.output_file, update_existing=not args.no_update)
+
     logger.info(f"Completed merging PR data. Total PRs in merged file: {total_prs}")
+
 
 if __name__ == "__main__":
     main()

--- a/pr_analysis/verify_pr_data.py
+++ b/pr_analysis/verify_pr_data.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+統合されたPRデータを検証するスクリプト
+"""
+
+import json
+import os
+from pathlib import Path
+
+def main():
+    repo_root = Path(__file__).parent.parent.absolute()
+    merged_file = os.path.join(repo_root, "pr_analysis_results", "merged", "merged_prs_data.json")
+    
+    try:
+        with open(merged_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            
+        total_prs = len(data)
+        pr_numbers = [pr.get("basic_info", {}).get("number", 0) for pr in data if "basic_info" in pr]
+        
+        if pr_numbers:
+            min_pr = min(pr_numbers)
+            max_pr = max(pr_numbers)
+            unique_pr_count = len(set(pr_numbers))
+            
+            print(f"合計PR数: {total_prs}")
+            print(f"PR番号の範囲: {min_pr} ~ {max_pr}")
+            print(f"ユニークなPR番号の数: {unique_pr_count}")
+            
+            missing_prs = sorted(set(range(1, max_pr + 1)) - set(pr_numbers))
+            print(f"欠落しているPR番号の数: {len(missing_prs)}")
+            if missing_prs:
+                print(f"欠落しているPR番号: {missing_prs}")
+                
+    except Exception as e:
+        print(f"エラー: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/pr_analysis/verify_pr_data.py
+++ b/pr_analysis/verify_pr_data.py
@@ -7,33 +7,35 @@ import json
 import os
 from pathlib import Path
 
+
 def main():
     repo_root = Path(__file__).parent.parent.absolute()
     merged_file = os.path.join(repo_root, "pr_analysis_results", "merged", "merged_prs_data.json")
-    
+
     try:
         with open(merged_file, "r", encoding="utf-8") as f:
             data = json.load(f)
-            
+
         total_prs = len(data)
         pr_numbers = [pr.get("basic_info", {}).get("number", 0) for pr in data if "basic_info" in pr]
-        
+
         if pr_numbers:
             min_pr = min(pr_numbers)
             max_pr = max(pr_numbers)
             unique_pr_count = len(set(pr_numbers))
-            
+
             print(f"合計PR数: {total_prs}")
             print(f"PR番号の範囲: {min_pr} ~ {max_pr}")
             print(f"ユニークなPR番号の数: {unique_pr_count}")
-            
+
             missing_prs = sorted(set(range(1, max_pr + 1)) - set(pr_numbers))
             print(f"欠落しているPR番号の数: {len(missing_prs)}")
             if missing_prs:
                 print(f"欠落しているPR番号: {missing_prs}")
-                
+
     except Exception as e:
         print(f"エラー: {e}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# PRデータ統合スクリプトの追加

## 変更内容
- 複数のPRデータファイルを統合するスクリプト `pr_analysis/merge_pr_data.py` を追加
- 検証用スクリプト `pr_analysis/verify_pr_data.py` と `pr_analysis/check_pr_counts.py` を追加
- READMEを更新してスクリプトの使用方法を追加

## 統合結果
4つのディレクトリ（20250521_021502、20250521_034352、20250521_034935、20250521_094649）から合計1361個のPRデータを統合しました。PR番号の範囲は1～1368で、7つのPR（181, 182, 194, 215, 802, 807, 931）は元のデータに含まれていません。

## 依頼者
NISHIO Hirokazu (nishio.hirokazu@gmail.com)

## Link to Devin run
https://app.devin.ai/sessions/31c053aadb75417e865e8ddf0b0d58e7