### PR TITLE
GitHub Actionsワークフローの追加：policy-pr-dataリポジトリへのデータ更新

### DIFF
--- a/.github/workflows/update-policy-pr-data.yml
+++ b/.github/workflows/update-policy-pr-data.yml
@@ -1,0 +1,47 @@
+name: Update Policy PR Data
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # 毎時0分に実行
+  workflow_dispatch:     # 手動トリガーを許可
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout random repository
+        uses: actions/checkout@v3
+        
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.lock
+          
+      - name: Run PR data collection
+        run: |
+          python pr_analysis/pr_analyzer.py --mode fetch --fetch-mode priority
+          
+      - name: Checkout policy-pr-data repository
+        uses: actions/checkout@v3
+        with:
+          repository: team-mirai/policy-pr-data
+          path: policy-pr-data
+          token: ${{ secrets.POLICY_PR_DATA_TOKEN }}
+          
+      - name: Copy and rename data file
+        run: |
+          cp pr_analysis_results/merged/merged_prs_data.json policy-pr-data/all-data.json
+          
+      - name: Commit and push changes
+        run: |
+          cd policy-pr-data
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git add all-data.json
+          git commit -m "Update PR data [skip ci]" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
# GitHub Actionsワークフローの追加：policy-pr-dataリポジトリへのデータ更新 
## 変更内容
- GitHub Actionsワークフローファイル（`.github/workflows/update-policy-pr-data.yml`）を追加
- 1時間ごとの自動実行と手動トリガーの設定
- policy-pr-dataリポジトリへのデータ転送処理の実装 

## 詳細

このPRでは、team-mirai/randomリポジトリで収集したPRデータを、team-mirai/policy-pr-dataリポジトリに自動的に転送するためのGitHub Actionsワークフローを追加しています。  ワークフローは以下の機能を持っています：
 - 1時間ごとの自動実行（cron: '0 * * * *'）
 - 手動トリガーオプション（workflow_dispatch）
 - randomリポジトリからpolicy-pr-dataリポジトリへのデータ転送（merged_prs_data.json → all-data.json）
 
Link to Devin run: https://app.devin.ai/sessions/197688fdc1f04295a013ee0d4746c703 Requested by: NISHIO Hirokazu (nishio.hirokazu@gmail.com) 


[x] CLAに同意します