### PR TITLE
Fix: priority モードで最新データが取得できない問題を修正

### DIFF
--- a/pr_analysis/pr_analyzer.py
+++ b/pr_analysis/pr_analyzer.py
@@ -199,7 +199,7 @@ def get_pull_requests_sequential(start_id=1, max_id=None, limit=None):
     return all_prs
 
 
-def get_pull_requests_priority(status_data, limit=None):
+def get_pull_requests_priority(status_data, limit=None, last_updated_at=None):
     """未取得のPRを優先的に取得する"""
     all_prs = []
     count = 0
@@ -239,7 +239,12 @@ def get_pull_requests_priority(status_data, limit=None):
         remaining_limit = limit - count
         print(f"未取得PRの取得が完了しました。残り {remaining_limit} 件を更新日時順で取得します...")
         
-        prs = get_pull_requests(limit=remaining_limit, sort_by="updated", direction="desc")
+        prs = get_pull_requests(
+            limit=remaining_limit, 
+            sort_by="updated", 
+            direction="desc",
+            last_updated_at=last_updated_at
+        )
         all_prs.extend(prs)
     
     return all_prs
@@ -898,7 +903,8 @@ def fetch_pr_data(args):
     elif args.fetch_mode == "priority":
         prs = get_pull_requests_priority(
             status_data=status_data,
-            limit=limit
+            limit=limit,
+            last_updated_at=last_updated_at
         )
     else:  # "updated"モード（デフォルト）
         prs = get_pull_requests(


### PR DESCRIPTION
# 問題
`python pr_analyzer.py --mode fetch --fetch-mode priority` コマンドを実行しても最新のデータが取得できない問題がありました。

# 原因
`get_pull_requests_priority` 関数が未取得のPRを優先的に取得した後、残りの制限数で更新日時順にPRを取得する際に、`last_updated_at` パラメータを渡していないことが原因でした。

# 修正内容
1. `get_pull_requests_priority` 関数に `last_updated_at` パラメータを追加
2. `fetch_pr_data` 関数から `get_pull_requests_priority` 関数を呼び出す際に `last_updated_at` パラメータを渡すように修正

この修正により、priorityモードでも前回取得したPRと同じ時刻のPRが見つかったら処理を終了する機能が有効になります。

Link to Devin run: https://app.devin.ai/sessions/b56a1c9f95f54805976be154cb65d8a1
Requested by: NISHIO Hirokazu (nishio.hirokazu@gmail.com)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/random/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
