### PR TITLE
GitHub Actionsによる定期的なPRデータ更新の自動化

### DIFF
--- a/.github/workflows/hourly_pr_data_update.yml
+++ b/.github/workflows/hourly_pr_data_update.yml
@@ -1,0 +1,73 @@
+name: Hourly PR Data Update
+
+on:
+  schedule:
+    # 1時間ごとに実行（UTC時間）
+    - cron: '0 * * * *'
+  workflow_dispatch:  # 手動実行も可能にする
+
+jobs:
+  update-pr-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout random repository
+        uses: actions/checkout@v3
+        with:
+          repository: team-mirai/random
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: random
+
+      - name: Checkout policy-pr-data repository
+        uses: actions/checkout@v3
+        with:
+          repository: team-mirai/policy-pr-data
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: policy-pr-data
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          cd random
+          pip install -r pr_analysis/requirements.txt
+          pip install requests tqdm
+
+      - name: Run PR data update script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd random
+          python pr_analysis/update_pr_data.py
+          echo "PR data update completed"
+
+      - name: Copy merged_prs_data.json to policy-pr-data repository
+        run: |
+          if [ -f "random/pr_analysis_results/merged/merged_prs_data.json" ]; then
+            mkdir -p policy-pr-data/data
+            cp random/pr_analysis_results/merged/merged_prs_data.json policy-pr-data/data/
+            echo "Copied merged_prs_data.json to policy-pr-data repository"
+          else
+            echo "Error: merged_prs_data.json not found"
+            exit 1
+          fi
+
+      - name: Commit and push to policy-pr-data repository
+        run: |
+          cd policy-pr-data
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git add data/merged_prs_data.json
+          
+          # 変更がある場合のみコミットする
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+            git commit -m "Update merged_prs_data.json - ${timestamp}"
+            git push
+            echo "Changes pushed to policy-pr-data repository"
+          fi


### PR DESCRIPTION
# GitHub Actionsによる定期的なPRデータ更新の自動化
 このPRでは、PR #16で追加されたupdate_pr_data.pyスクリプトを1時間ごとに実行し、生成されたmerged_prs_data.jsonファイルをpolicy-pr-dataリポジトリのmainブランチにプッシュするGitHub Actionsワークフローを追加しています。

## 変更内容
 - 1時間ごとに実行されるGitHub Actionsワークフローを追加
 - update_pr_data.pyスクリプトを実行してPRデータを更新
 - 生成されたmerged_prs_data.jsonファイルをpolicy-pr-dataリポジトリにプッシュ 
 
 ## 動作の流れ
1. 1時間ごと（または手動実行時）にワークフローが起動
3. randomリポジトリとpolicy-pr-dataリポジトリをチェックアウト
4. 3. Pythonと必要な依存関係をセットアップ
5. 4. update_pr_data.pyスクリプトを実行してPRデータを更新
6. 5. 生成されたmerged_prs_data.jsonファイルをpolicy-pr-dataリポジトリにコピー
7. 6. 変更があればpolicy-pr-dataリポジトリにコミットしてプッシュ

## Link to Devin run 
https://app.devin.ai/sessions/0e072afee8094260ae36e76577cd38f7 
## Requested by NISHIO Hirokazu (nishio.hirokazu@gmail.com) 


[x] CLAに同意します